### PR TITLE
Skip before action of authentication on supply index and show routes

### DIFF
--- a/app/controllers/supplies_controller.rb
+++ b/app/controllers/supplies_controller.rb
@@ -1,5 +1,6 @@
 class SuppliesController < ApplicationController
   before_action :set_supply, only: [:show, :edit, :update]
+  skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
     authorize @supplies


### PR DESCRIPTION
- Added skip_before_action for authenticate_user for the index and show methods in Supplies controller
- Users should now be able to view all supplies and individual supplies while being logged out