### PR TITLE
Added delete functionality for supply

### DIFF
--- a/app/controllers/supplies_controller.rb
+++ b/app/controllers/supplies_controller.rb
@@ -1,5 +1,5 @@
 class SuppliesController < ApplicationController
-  before_action :set_supply, only: [:show, :edit, :update]
+  before_action :set_supply, only: [:show, :edit, :update, :destroy]
   skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
@@ -37,6 +37,12 @@ class SuppliesController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    authorize_supply
+    @supply.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/policies/supply_policy.rb
+++ b/app/policies/supply_policy.rb
@@ -20,4 +20,8 @@ class SupplyPolicy < ApplicationPolicy
   def update?
     record.user == user
   end
+
+  def destroy?
+    record.user == user
+  end
 end

--- a/app/views/supplies/show.html.erb
+++ b/app/views/supplies/show.html.erb
@@ -29,6 +29,13 @@
               <%= link_to "edit", edit_supply_path(@supply)  %>
             <% end %>
           </div>
+          <div>
+            <% if policy(@supply).destroy? %>
+              <%= link_to supply_path(@supply), method: :delete, data: { confirm: "Are you sure?" } do %>
+                <i class="fa fa-trash destroy_dose"></i>
+              <% end %>
+            <% end %>
+          </div>
     </div>
 
 


### PR DESCRIPTION
- Added destroy method to Supplies controller with the authorize
- Updated Supply policy to check whether the current user is the user who created the Supply
- Added delete button to show view for Supply, displays only when the Supply policy for delete is true, so that only the original creator can delete the supply